### PR TITLE
Fix va2cpp.makefile on Windows

### DIFF
--- a/qucs-core/src/components/verilog/va2cpp.makefile
+++ b/qucs-core/src/components/verilog/va2cpp.makefile
@@ -58,7 +58,7 @@ va2cpp: $(MODEL).cpp
 
 .va.cpp: $(XML_FILES)
 	@echo '# va2cpp - Creating C++ sources.'
-	$(ADMSXML) $< \
+	"$(ADMSXML)" $< \
                            -I "$(INC)"                    \
                            -e "$(INC)/qucsVersion.xml"    \
                            -e "$(INC)/qucsMODULEcore.xml" \


### PR DESCRIPTION
Quoting "$(ADMSXML)" helps in case white spaces are in the path.
Things may end up in "C:\Program Files\" or the like.
