### PR TITLE
Some hot-fixes just to compile 'qucslib_symbol' branch

### DIFF
--- a/qucs/qucs-lib/libcomp.h
+++ b/qucs/qucs-lib/libcomp.h
@@ -25,7 +25,9 @@
 #include <assert.h>
 
 #include "symbolwidget.h" // Line etc.
-/*!
+#include "./../qucs/element.h"
+
+/*
  * \brief this library provides symbols. these.
  */
 

--- a/qucs/qucs-lib/symbolwidget.h
+++ b/qucs/qucs-lib/symbolwidget.h
@@ -31,6 +31,7 @@
 
 #include "qucslib_common.h"
 #include "libcomp.h"
+#include "./../qucs/symbol.h"
 /*!
  * \file symbolwidget.h
  * \brief Definition of the SymbolWidget class.
@@ -40,54 +41,6 @@
 class Node;
 class QPaintEvent;
 class QSizePolicy;
-
-
-struct Line {
-  Line(int _x1, int _y1, int _x2, int _y2, QPen _style)
-       : x1(_x1), y1(_y1), x2(_x2), y2(_y2), style(_style) {};
-  int   x1, y1, x2, y2;
-  QPen  style;
-};
-
-struct Arc {
-  Arc(int _x, int _y, int _w, int _h, int _angle, int _arclen, QPen _style)
-      : x(_x), y(_y), w(_w), h(_h), angle(_angle),
-	arclen(_arclen), style(_style) {};
-  int   x, y, w, h, angle, arclen;
-  QPen  style;
-};
-
-struct Area {
-  Area(int _x, int _y, int _w, int _h, QPen _Pen,
-	QBrush _Brush = QBrush(Qt::NoBrush))
-	: x(_x), y(_y), w(_w), h(_h), Pen(_Pen), Brush(_Brush) {};
-  int    x, y, w, h;
-  QPen   Pen;
-  QBrush Brush;    // filling style/color
-};
-
-struct Port {
-  Port() {};
-  Port(int _x, int _y, bool _avail=true) : x(_x), y(_y), avail(_avail) {
-    Type=""; Connection=0;};
-  int   x, y;
-  bool  avail;
-  QString Type;
-  Node *Connection;
-};
-
-struct Text {
-  Text(int _x, int _y, const QString& _s, QColor _Color = QColor(0,0,0),
-	float _Size = 10.0, float _mCos=1.0, float _mSin=0.0)
-	: x(_x), y(_y), s(_s), Color(_Color), Size(_Size),
-	  mSin(_mSin), mCos(_mCos) { over = under = false; };
-  int	  x, y;
-  QString s;
-  QColor  Color;
-  float	  Size, mSin, mCos; // font size and rotation coefficients
-  bool	  over, under;      // text attributes
-};
-
 class QucsLibComponent;
 
 class SymbolWidget : public QWidget  {

--- a/qucs/qucs/main.h
+++ b/qucs/qucs/main.h
@@ -36,7 +36,7 @@ class QucsApp;
 class Component;
 
 static const double pi = 3.1415926535897932384626433832795029;  /* pi   */
-
+/*
 struct tQucsSettings {
   int x, y, dx, dy;    // position and size of main window
   QFont font;
@@ -80,7 +80,7 @@ struct tQucsSettings {
   bool IgnoreFutureVersion;
   bool GraphAntiAliasing;
   bool TextAntiAliasing;
-};
+};*/
 
 extern tQucsSettings QucsSettings;  // extern because nearly everywhere used
 extern QucsApp *QucsMain;  // the Qucs application itself

--- a/qucs/qucs/settings.h
+++ b/qucs/qucs/settings.h
@@ -33,6 +33,8 @@ struct tQucsSettings {
   QDir AdmsXmlBinDir;  // dir of admsXml executable
   QDir AscoBinDir;     // dir of asco executable
   QDir OctaveBinDir;   // dir of octave executable
+  QString OctaveExecutable;//Are these three fields just the same?
+  QString QucsOctave;
 
   // registered filename extensions with program to open the file
   QStringList FileTypes;


### PR DESCRIPTION
@felix-salfelder I've been taking a look to your branch qucslib_symbol and, after some hot-fixes, it compiles on my side (see the commit for details)

There was some missing #include"" over there. I've also found that the compiler complained about
two missing fields in tQucsSettings structure. I added these fields to the structure, but I'm not sure about their purpose:

QDir OctaveBinDir;   // dir of octave executable
QString OctaveExecutable;//Are these three fields just the same? Do they point to the Octave binary?
QString QucsOctave;

(I need to do some research on this...)

Hope this helps